### PR TITLE
Added blocks Gus can't rotate on

### DIFF
--- a/game/js/objects/blackbrick.js
+++ b/game/js/objects/blackbrick.js
@@ -1,0 +1,15 @@
+function BlackBrickBlock( x, y ) {
+
+  x = Math.floor( x / 32 ) * 32;
+  y = Math.floor( y / 32 ) * 32;
+
+  this.sprite = game.add.sprite( x, y, 'BrickBlack' );
+
+  game.physics.p2.enable( this.sprite, false );
+
+  this.sprite.body.setRectangle( 32, 32 );
+  this.sprite.body.setCollisionGroup( COLLISION_GROUPS.BLOCK_SOLID );
+  this.sprite.body.collides( [ COLLISION_GROUPS.PLAYER_SOLID ] );
+  this.sprite.body.static = true;
+
+}

--- a/game/js/objects/gus.js
+++ b/game/js/objects/gus.js
@@ -229,6 +229,7 @@ Gus.prototype.update = function() {
 
     if ( this.rotationSensor.needsCollisionData ) {
       this.sprite.body.setCollisionGroup( COLLISION_GROUPS.PLAYER_SOLID );
+      this.sprite.body.setCollisionGroup( COLLISION_GROUPS.PLAYER_SENSOR, this.rotationSensor );
       this.sprite.body.collides( [ COLLISION_GROUPS.BLOCK_SOLID, COLLISION_GROUPS.BLOCK_ROTATE ] );
       this.rotationSensor.needsCollisionData = false;
     }

--- a/game/js/states/game.js
+++ b/game/js/states/game.js
@@ -26,9 +26,13 @@ function initGameState() {
       var block = new RedBrickBlock( -128 + (32 * i), 128 );
     }
 
+    for ( var i = 0; i < 10; ++i ) {
+      var block = new BlackBrickBlock( 64, 96 - ( 32 * i ) );
+    }
+
     console.log( "Binding to keys..." );
 
-    cursors = game.input.keyboard.createCursorKeys();
+    window.cursors = game.input.keyboard.createCursorKeys();
     marker.setPlaceGirderButton( game.input.keyboard.addKey( Phaser.KeyCode.SPACEBAR ) );
 
   }


### PR DESCRIPTION
To prevent Gus from rotating to a block, simply don't collide with COLLISION_GROUPS.PLAYER_SENSOR
