### PR TITLE
Added gameView directive

### DIFF
--- a/browser/js/app.js
+++ b/browser/js/app.js
@@ -1,5 +1,5 @@
 'use strict';
-window.app = angular.module('FullstackGeneratedApp', ['fsaPreBuilt', 'ui.router']);
+window.app = angular.module('FullstackGeneratedApp', ['fsaPreBuilt', 'ui.router', 'ngLoadScript']);
 
 app.config(function($urlRouterProvider, $locationProvider) {
     // This turns off hashbang urls (/#about) and changes it to something normal (/about)

--- a/browser/js/game/game-view.html
+++ b/browser/js/game/game-view.html
@@ -1,0 +1,7 @@
+<div class="game-view">
+  <script type="text/javascript-lazy" src="/phaser/dist/phaser.min.js"></script>
+  <script type="text/javascript-lazy" src="/phaser-debug/dist/phaser-debug.js"></script>
+  <script type="text/javascript-lazy" src="/girder-gus.js"></script>
+
+  <div class="game-container"></div>
+</div>

--- a/browser/js/game/game-view.js
+++ b/browser/js/game/game-view.js
@@ -1,0 +1,12 @@
+app.directive( "gameView", function() {
+
+  return {
+    restrict: 'E',
+    templateUrl: '/js/game/game-view.html',
+    scope: {
+      level: '=',
+      state: '='
+    }
+  }
+
+});

--- a/browser/js/submodules/ng-load-script.js
+++ b/browser/js/submodules/ng-load-script.js
@@ -1,0 +1,58 @@
+/*
+* Angular LoadScript
+*
+* Let angular load and execute lazy javascript from partials!
+*
+* This module is the result of this issue: "1.2.0rc1 regression: script tags not loaded via ngInclude"
+* Issue url: https://github.com/angular/angular.js/issues/3756
+*
+* As of Angular 1.2.0 the ngInclude scripts does not permit execution of javascript from included partials.
+* This little module execute code inside script tags with "javascript-lazy" attribute after partial loading,
+* thus re-enabling this feature.
+*
+* ( please have a look at the issue comments, this angular feature was never planned nor included properly,
+* was only a drawback of using jQuery for partial inclusion )
+*
+* This angular module have been created by @subudeepak(https://github.com/subudeepak) based on the code posted by @endorama (https://github.com/endorama)
+* (based upon the code
+* posted by @olostan (https://github.com/olostan) )
+*
+* Simply add this file, load ngLoadScript module as application dependency and use type="text/javascript-lazy"
+* as type for script you which to load lazily in partials.
+*
+* License: 2013 - released to the Public Domain.
+*/
+
+/*global angular */
+(function (ng) {
+  'use strict';
+
+  var app = ng.module('ngLoadScript', []);
+
+  app.directive('script', function() {
+    return {
+      restrict: 'E',
+      scope: false,
+      link: function(scope, elem, attr)
+      {
+        if (attr.type==='text/javascript-lazy')
+        {
+          var s = document.createElement("script");
+          s.type = "text/javascript";
+          var src = elem.attr('src');
+          if(src!==undefined)
+          {
+            s.src = src;
+          }
+          else
+          {
+            var code = elem.text();
+            s.text = code;
+          }
+          document.head.appendChild(s);
+          elem.remove();
+        }
+      }
+    };
+  });
+}(angular));

--- a/game/js/main.js
+++ b/game/js/main.js
@@ -4,7 +4,7 @@ var   WIDTH   = FULLSCREEN ? window.innerWidth * window.devicePixelRatio : 800,
       HEIGHT  = FULLSCREEN ? window.innerHeight * window.devicePixelRatio : 600;
 
 // initialize the game
-var   game    = new Phaser.Game( WIDTH, HEIGHT, Phaser.AUTO, 'gameContainer' );
+var   game    = new Phaser.Game( WIDTH, HEIGHT, Phaser.AUTO, 'game-container' );
 
 // add states
 game.state.add( "boot", initBootState() );

--- a/game/js/states/load.js
+++ b/game/js/states/load.js
@@ -7,12 +7,12 @@ function initLoadState() {
 
     console.log( "Loading assets..." );
 
-    game.load.image('BrickBlack', 'public/assets/images/brick_black.png');
-    game.load.image('BrickBreak', 'public/assets/images/brick_break.png');
-    game.load.image('BrickRed', 'public/assets/images/brick_red.png');
-    game.load.image('Girder', 'public/assets/images/girder.png');
-    game.load.image('Tool', 'public/assets/images/tool.png');
-    game.load.spritesheet('Gus', 'public/assets/images/gus.png', 32, 32);
+    game.load.image('BrickBlack', '/assets/images/brick_black.png');
+    game.load.image('BrickBreak', '/assets/images/brick_break.png');
+    game.load.image('BrickRed', '/assets/images/brick_red.png');
+    game.load.image('Girder', '/assets/images/girder.png');
+    game.load.image('Tool', '/assets/images/tool.png');
+    game.load.spritesheet('Gus', '/assets/images/gus.png', 32, 32);
 
     console.log( "Done loading" );
 


### PR DESCRIPTION
This adds the gameView directive, which can be included in HTML like this:

```
<div class="container">
    <!-- some stuff here -->
    <game-view></game-view>
</div>
```

This pull request also includes the ngLoadScript submodule for lazy loading the game's javascript when the directive is used.
