### PR TITLE
levelCreator screenshots

### DIFF
--- a/browser/js/states/createLevel/createLevel.controller.js
+++ b/browser/js/states/createLevel/createLevel.controller.js
@@ -38,5 +38,14 @@ app.controller('CreateLevelCtrl', function($scope) {
   eventEmitter.on('send tile map', (parsedTileMap) => {
     console.log('recieved.')
     console.dir(parsedTileMap);
+  });
+
+  $scope.getScreenshot = function() {
+    eventEmitter.emit('request screenshot');
+  }
+
+  eventEmitter.on('send screenshot', (screenshot) => {
+    console.log('screenshot');
+    console.log(screenshot);
   })
 });

--- a/browser/js/states/createLevel/createLevel.html
+++ b/browser/js/states/createLevel/createLevel.html
@@ -17,4 +17,5 @@
 	</level-creator>
 
   <button ng-click='requestParsedTileMap()'>GET TILE MAP</button>
+  <button ng-click='getScreenshot()'>GET SCREENSHOT</button>
 </div>

--- a/levelCreator/main.js
+++ b/levelCreator/main.js
@@ -10,6 +10,9 @@ function startGame( phaser ) {
 
   // initialize the game
   window.game = new phaser.Game( WIDTH, HEIGHT, Phaser.AUTO, 'level-creator-container', undefined, undefined, false );
+  
+  // necessary for screenshots when using WebGL renderer
+  game.preserveDrawingBuffer = true;
 
   // add states
   game.state.add( "load", loadState() );

--- a/levelCreator/states/create.js
+++ b/levelCreator/states/create.js
@@ -57,6 +57,11 @@ function initCreateState() {
       console.log('sending...')
       eventEmitter.emit('send tile map', parsedTileMap);
     })
+
+    eventEmitter.on('request screenshot', function() {
+      var screenshot = game.canvas.toDataURL();
+      eventEmitter.emit('send screenshot', screenshot);
+    })
   }
 
   state.update = function() {


### PR DESCRIPTION
set game.preserveDrawingBuffer=true to preserve webGL buffer, can request & receive screenshot (base64 PNG) using button linked to eventEmitter
