### PR TITLE
selector and grid are now always on top of placed blocks

### DIFF
--- a/levelCreator/states/create.js
+++ b/levelCreator/states/create.js
@@ -175,6 +175,7 @@ function initCreateState() {
 			if (game.activeTool) {
 				placedTool = game.add.sprite(x, y, game.activeTool);
 				placedTool.anchor.setTo(0.5, 0.5);
+				game.world.sendToBack(placedTool);
 			}
 
 			if (game.activeTool === 'Spike') {


### PR DESCRIPTION
very simple fix, sprites added during level creation are now sent to back using game.world.sendToBack(sprite)
world can also bringToFront(sprite), cool stuff
closes #109 
