### PR TITLE
Starring & following fixes

### DIFF
--- a/browser/js/directives/user-minicard/user-minicard.controller.js
+++ b/browser/js/directives/user-minicard/user-minicard.controller.js
@@ -6,27 +6,59 @@ app.controller('UserMinicardCtrl', function($scope, SocialFactory) {
     })();
     $scope.pending = false;
 
-    $scope.followCreator = function() {
-        if($scope.user !== null) {
-            $scope.pending = true;
-            SocialFactory.userFollower($scope.creator._id, 'followUser')
-                .then(function(res) {
+    var optimistic = false;
+    var optimisticCache;
+    var optimisticTimer;
+
+    var serverFollowToggle = function(action) {
+        SocialFactory.userFollower($scope.creator._id, action)
+            .then(function(res) {
+                if(optimisticCache !== undefined && action !== optimisticCache) {
+                    var cacheAction = optimisticCache;
+                    optimisticCache = undefined;
+                    serverFollowToggle(cacheAction);
+                } else {
+                    clearTimeout(optimisticTimer);
+                    optimistic = false;
+                    optimisticCache = undefined;
                     $scope.creator.totalFollowers = res.creator.totalFollowers;
                     $scope.followed = res.user.following.indexOf($scope.creator._id) !== -1;
                     $scope.pending = false;
-                })
+                }
+            });
+    }
+
+    $scope.followCreator = function() {
+        $scope.pending = true;
+        optimisticTimer = setTimeout(function() {
+            $scope.followed = true;
+            $scope.creator.totalFollowers++;
+            $scope.pending = false;
+            optimistic = true;
+            $scope.$digest();
+        }, 200);
+
+        if(optimistic) {
+            optimisticCache = 'followUser';
+        } else {
+            serverFollowToggle('followUser');
         }
     }
 
     $scope.unfollowCreator = function() {
-        if($scope.user !== null) {
-            $scope.pending = true;
-            SocialFactory.userFollower($scope.creator._id, 'unfollowUser')
-                .then(function(res) {
-                    $scope.creator.totalFollowers = res.creator.totalFollowers;
-                    $scope.followed = res.user.following.indexOf($scope.creator._id) !== -1;
-                    $scope.pending = false;
-                })
+        $scope.pending = true;
+        optimisticTimer = setTimeout(function() {
+            $scope.followed = false;
+            $scope.creator.totalFollowers--;
+            $scope.pending = false;
+            optimistic = true;
+            $scope.$digest();
+        }, 200);
+
+        if(optimistic) {
+            optimisticCache = 'unfollowUser';
+        } else {
+            serverFollowToggle('unfollowUser');
         }
     }
 });

--- a/browser/js/directives/user-minicard/user-minicard.html
+++ b/browser/js/directives/user-minicard/user-minicard.html
@@ -3,9 +3,11 @@
   <div class="star-count"><span class="glyphicon glyphicon-star"></span> {{ creator.totalStars }}</div>
   <h3>{{ creator.name }}</h3>
   <p>{{ creator.totalFollowers }} follower<span ng-show="creator.totalFollowers !== 1">s</span></p>
-  <a class="btn btn-follow" href="#" ng-show="!followed && !pending" ng-click="followCreator()">Follow</a>
-  <a class="btn btn-disabled" ng-show="!followed && pending"><span class="glyphicon glyphicon-time"></span> Following</a>
-  <a class="btn btn-unfollow" href="#" ng-show="followed && !pending" ng-click="unfollowCreator()">Unfollow</a>
-  <a class="btn btn-disabled" ng-show="followed && pending"><span class="glyphicon glyphicon-time"></span> Unfollowing</a>
-  <div class="more-by"><a href="#">More by this builder</a></more-by>
+  <div class="controls" ng-if="user!==null&&user._id!==creator._id">
+      <a class="btn btn-follow-hollow" href="#" ng-show="!followed && !pending" ng-click="followCreator()"><span class="glyphicon glyphicon-user"></span> Follow</a>
+      <a class="btn btn-disabled" ng-show="!followed && pending"><span class="glyphicon glyphicon-time"></span> Follow</a>
+      <a class="btn btn-follow" href="#" ng-show="followed && !pending" ng-click="unfollowCreator()"><span class="glyphicon glyphicon-user"></span> Following</a>
+      <a class="btn btn-disabled" ng-show="followed && pending"><span class="glyphicon glyphicon-time"></span> Following</a>
+    </div>
+  <div class="more-by" ng-if="user._id!==creator._id"><a href="#">More by this builder</a></more-by>
 </div>

--- a/browser/js/states/levelDetails/level-details.controller.js
+++ b/browser/js/states/levelDetails/level-details.controller.js
@@ -24,6 +24,8 @@ app.controller('LevelDetailsCtrl', function ($scope, $state, data, user, SocialF
     var optimisticTimer;
 
     var serverStarToggle = function(action) {
+        var levelStars = $scope.level.starCount;
+        var creatorStars = $scope.creator.totalStars;
         SocialFactory.levelLiker(data._id, action)
             .then(function(res) {
                 if(optimisticCache !== undefined && action !== optimisticCache) {
@@ -36,12 +38,19 @@ app.controller('LevelDetailsCtrl', function ($scope, $state, data, user, SocialF
                     optimisticCache = undefined;
                     $scope.level.starCount = res.level.starCount;
                     $scope.creator.totalStars = res.creator.totalStars;
-                    $scope.liked = res.user.likedLevels.indexOf(data._id) !== -1;
+                    $scope.user.likedLevels = res.user.likedLevels;
+                    $scope.liked = $scope.user.likedLevels.indexOf(data._id) !== -1;
                     $scope.pending = false;
                 }
             })
             .then(null,function(err) {
-                console.log(err);
+                clearTimeout(optimisticTimer);
+                optimistic = false;
+                optimisticCache = undefined;
+                $scope.level.starCount = levelStars;
+                $scope.creator.totalStars = creatorStars;
+                $scope.liked = $scope.user.likedLevels.indexOf(data._id) !== -1;
+                $scope.pending = false;
             });
     }
 

--- a/browser/js/states/levelDetails/level-details.controller.js
+++ b/browser/js/states/levelDetails/level-details.controller.js
@@ -39,6 +39,9 @@ app.controller('LevelDetailsCtrl', function ($scope, $state, data, user, SocialF
                     $scope.liked = res.user.likedLevels.indexOf(data._id) !== -1;
                     $scope.pending = false;
                 }
+            })
+            .then(null,function(err) {
+                console.log(err);
             });
     }
 

--- a/browser/js/states/levelDetails/level-details.controller.js
+++ b/browser/js/states/levelDetails/level-details.controller.js
@@ -19,32 +19,62 @@ app.controller('LevelDetailsCtrl', function ($scope, $state, data, user, SocialF
     console.log('data',data);
     $scope.user = user;
     $scope.pending = false;
+    var optimistic = false;
+    var optimisticCache;
+    var optimisticTimer;
 
-    $scope.starLevel = function() {
-        if(user !== null) {
-            $scope.pending = true;
-            SocialFactory.levelLiker(data._id,'likeLevel')
-                .then(function(res) {
-                    console.log(res);
+    var serverStarToggle = function(action) {
+        SocialFactory.levelLiker(data._id, action)
+            .then(function(res) {
+                if(optimisticCache !== undefined && action !== optimisticCache) {
+                    var cacheAction = optimisticCache;
+                    optimisticCache = undefined;
+                    serverStarToggle(cacheAction);
+                } else {
+                    clearTimeout(optimisticTimer);
+                    optimistic = false;
+                    optimisticCache = undefined;
                     $scope.level.starCount = res.level.starCount;
                     $scope.creator.totalStars = res.creator.totalStars;
                     $scope.liked = res.user.likedLevels.indexOf(data._id) !== -1;
                     $scope.pending = false;
-                });
+                }
+            });
+    }
+
+    $scope.starLevel = function() {
+        $scope.pending = true;
+        optimisticTimer = setTimeout(function() {
+            $scope.level.starCount++;
+            $scope.creator.totalStars++;
+            $scope.liked = true;
+            $scope.pending = false;
+            optimistic = true;
+            $scope.$digest();
+        }, 200);
+
+        if(optimistic) {
+            optimisticCache = 'likeLevel';
+        } else {
+            serverStarToggle('likeLevel');
         }
     }
 
     $scope.unstarLevel = function() {
-        if(user !== null) {
-            $scope.pending = true;
-            SocialFactory.levelLiker(data._id,'unlikeLevel')
-                .then(function(res) {
-                    console.log(res);
-                    $scope.level.starCount = res.level.starCount;
-                    $scope.creator.totalStars = res.creator.totalStars;
-                    $scope.liked = res.user.likedLevels.indexOf(data._id) !== -1;
-                    $scope.pending = false;
-                });
+        $scope.pending = true;
+        optimisticTimer = setTimeout(function() {
+            $scope.level.starCount--;
+            $scope.creator.totalStars--;
+            $scope.liked = false;
+            $scope.pending = false;
+            optimistic = true;
+            $scope.$digest();
+        }, 200);
+
+        if(optimistic) {
+            optimisticCache = 'unlikeLevel';
+        } else {
+            serverStarToggle('unlikeLevel');
         }
     }
 

--- a/browser/js/states/levelDetails/level-details.html
+++ b/browser/js/states/levelDetails/level-details.html
@@ -9,11 +9,11 @@
     <p><span class="label">Total Stars:</span> {{ level.starCount }}</p>
     <p><span class="label">Date Created:</span> {{ level.dateCreated | date }}</p>
   </div>
-  <div class="controls">
-    <a class="btn btn-star" href="#" ng-show="!liked && !pending" ng-click="starLevel()"><span class="glyphicon glyphicon-star"></span> Star</a>
-    <a class="btn btn-disabled" ng-show="!liked && pending"><span class="glyphicon glyphicon-time"></span> Starring</a>
-    <a class="btn btn-star" href="#" ng-show="liked && !pending" ng-click="unstarLevel()"><span class="glyphicon glyphicon-star-empty"></span> Unstar</a>
-    <a class="btn btn-disabled" ng-show="liked && pending"><span class="glyphicon glyphicon-time"></span> Unstarring</a>
+  <div class="controls" ng-if="user!==null&&user._id!==creator._id">
+    <a class="btn btn-star-hollow" href="#" ng-show="!liked && !pending" ng-click="starLevel()"><span class="glyphicon glyphicon-star-empty"></span> STAR</a>
+    <a class="btn btn-disabled" ng-show="!liked && pending"><span class="glyphicon glyphicon-time"></span> STAR</a>
+    <a class="btn btn-star" href="#" ng-show="liked && !pending" ng-click="unstarLevel()"><span class="glyphicon glyphicon-star"></span> STARRED</a>
+    <a class="btn btn-disabled" ng-show="liked && pending"><span class="glyphicon glyphicon-time"></span> STARRED</a>
     <a class="btn btn-create" ng-click='edit()'>New From Level</a>
   </div>
 </div>

--- a/browser/sass/common/_buttons.sass
+++ b/browser/sass/common/_buttons.sass
@@ -29,3 +29,15 @@
 
   &.btn-disabled
     background-color: grey
+
+  &.btn-star-hollow
+    background-color: rgba(0, 0, 0, 0)
+
+    &:hover
+      background-color: $color1
+
+  &.btn-follow-hollow
+    background-color: rgba(0, 0, 0, 0)
+
+    &:hover
+      background-color: royalblue

--- a/server/db/models/userModel.js
+++ b/server/db/models/userModel.js
@@ -185,8 +185,6 @@ schema.methods.likeLevel = function(levelId) {
     var Level = mongoose.model('Level');
     return Level.findById(levelId)
         .then(function(level) {
-            console.dir(level.creator)
-            console.dir(self._id);
             if(level === null) {
                 var err = new Error( "Cannot like level: Level does not exist");
                 err.status = 404;

--- a/server/db/models/userModel.js
+++ b/server/db/models/userModel.js
@@ -69,12 +69,29 @@ schema.methods.setStars = function() {
 //
 schema.methods.followUser = function(userId) {
     var self = this;
+    if(self._id === userId) {
+        var err = new Error();
+        err.status = 400;
+        throw err;
+    }
     return this.model('User').findById(userId)
         .then(function(user) {
             // throw error if no user has userId
-            if(user === null) throw new Error('User #'+userId+' not found');
+            if(user === null) {
+                var err = new Error('User #'+userId+' not found');
+                throw err;
+            }
             // throw error if user is already following userId
-            if(self.following.indexOf(user._id) !== -1) throw new Error('Already following user #'+user._id);
+            if(self.following.indexOf(user._id) !== -1) {
+                err = new Error('Already following user #'+user._id);
+                err.status = 400;
+                throw err;
+            }
+            if(user._id.equals(self._id)) {
+                err = new Error('Can\'t follow self');
+                err.status = 400;
+                throw err;
+            }
 
             self.following.push(user._id);
             self.totalFollowing = self.following.length;
@@ -168,6 +185,8 @@ schema.methods.likeLevel = function(levelId) {
     var Level = mongoose.model('Level');
     return Level.findById(levelId)
         .then(function(level) {
+            console.dir(level.creator)
+            console.dir(self._id);
             if(level === null) {
                 var err = new Error( "Cannot like level: Level does not exist");
                 err.status = 404;
@@ -177,11 +196,17 @@ schema.methods.likeLevel = function(levelId) {
                 err = new Error( "Cannot like level: Level has already been liked" );
                 err.status = 400;
                 throw err;
-            } else {
-                self.likedLevels.push(levelId);
-                self.totalLikedLevels = self.likedLevels.length;
-                return Promise.all([self.save(),level]);
             }
+            if(level.creator.equals(self._id)) {
+                err = new Error("Cannot like own level");
+                err.status = 400;
+                console.log(err);
+                throw err;
+            }
+
+            self.likedLevels.push(levelId);
+            self.totalLikedLevels = self.likedLevels.length;
+            return Promise.all([self.save(),level]);
         })
         .then(function(data) {
             var user = data[0];


### PR DESCRIPTION
- Revamped look of star & follow buttons
- Star & look buttons optimistically assume good responses to requests
  - Cache new requests while awaiting response
  - Revert if response is an error
- Users no longer see star & follow buttons if they aren't logged in or are looking at their own level
  - User schema also blocks users from starring own levels and following themselves
