### PR TITLE
separated drafts and complete levels when retrieving levels and summing totalCreatedLevels

### DIFF
--- a/browser/js/states/createLevel/createLevel.factory.js
+++ b/browser/js/states/createLevel/createLevel.factory.js
@@ -1,6 +1,7 @@
 app.factory('CreateLevelFactory', function ($http) {
 	var factory = {};
 	factory.submitLevel = function(objArr, title, girderCount, skyColor, isPublished, id) {
+		console.log('id',id,'isPublished',isPublished);
 		try { 
 			var map = {
 				startGirders: girderCount,

--- a/browser/js/states/profile/profile.controller.js
+++ b/browser/js/states/profile/profile.controller.js
@@ -1,5 +1,6 @@
 app.controller('ProfileCtrl', function($scope, profile, UsersFactory) {
     var rowSize = 4;
+    console.log(profile);
     var makeRows = function(levels) {
         return levels.reduce( function( levelMap, level ) {
             if ( levelMap[ levelMap.length - 1 ].length < rowSize ) {
@@ -22,17 +23,20 @@ app.controller('ProfileCtrl', function($scope, profile, UsersFactory) {
     $scope.pages = {
         createdLevels: makePages(profile.createdLevels.pages),
         followingLevels: makePages(profile.followingLevels.pages),
-        likedLevels: makePages(profile.likedLevels.pages)
+        likedLevels: makePages(profile.likedLevels.pages),
+        draftLevels: makePages(profile.draftLevels.pages)
     };
     $scope.currentPage = {
         createdLevels: 1,
         followingLevels: 1,
-        likedLevels: 1
+        likedLevels: 1,
+        draftLevels: 1
     };
 
     $scope.createdLevels = makeRows(profile.createdLevels.levels);
     $scope.followingLevels = makeRows(profile.followingLevels.levels);
     $scope.likedLevels = makeRows(profile.likedLevels.levels);
+    $scope.draftLevels = makeRows(profile.draftLevels.levels);
 
     $scope.loadCreatedPages = function(page) {
         UsersFactory.fetchProfileLevels('created', page)
@@ -56,6 +60,13 @@ app.controller('ProfileCtrl', function($scope, profile, UsersFactory) {
                 $scope.likedLevels = makeRows(data.levels);
                 $scope.currentPage.likedLevels = page;
                 $scope.pages.likedLevels = makePages(data.pages);
+            })
+    };
+    $scope.loadDraftPages = function(page) {
+        UsersFactory.fetchProfileLevels('drafts', page)
+            .then(function(data) {
+                $scope.draftLevels = makeRows(data.levels);
+                $scope.currentPage.draftLevels = page;
             })
     };
 

--- a/browser/js/states/profile/profile.html
+++ b/browser/js/states/profile/profile.html
@@ -24,6 +24,27 @@
           </ul>
         </nav>
     </div>
+    <div class="profile-levels-list" id="draft-levels">
+        <h4 id="created-levels">Drafts You're Working On</h4>
+        <div class="levels-list">
+            <div class="row" ng-repeat="levelRow in draftLevels">
+                <level-thumbnail ng-repeat="level in levelRow" level="level" edit="true"></level-thumbnail>
+            </div>
+        </div>
+        <nav ng-show="pages.draftLevels.length > 1">
+          <ul class="pagination">
+            <li ng-class="{disabled: currentPage.draftLevels === 1}">
+                <a ng-click="loadDraftPages(currentPage.draftLevels-1)">« Prev</a>
+            </li>
+            <li ng-repeat="page in pages.draftLevels" ng-class="{active: page === currentPage.draftLevels}">
+                <a ng-class="{disabled: page === currentPage.draftLevels}" ng-click="loadDraftPages(page)">{{ page }}</a>
+            </li>
+            <li ng-class="{disabled: currentPage.draftLevels === pages.draftLevels.length}">
+              <a ng-click="loadDraftPages(currentPage.draftLevels+1)">Next »</a>
+            </li>
+          </ul>
+        </nav>
+    </div>
     <div class="profile-levels-list" id="following-levels">
         <h4>Levels By Creators You're Following</h4>
         <div class="levels-list">

--- a/server/routes/helpers/crud.js
+++ b/server/routes/helpers/crud.js
@@ -42,15 +42,24 @@ const getLevelsByType = (userPromise, levelType, page) => {
     skip: page*8
   };
 
-  if(levelType === 'created') {
+  if(levelType === 'created' || levelType === 'drafts') {
     levelPromise = userPromise
       .then(user => {
-        var count = user.createdLevels.length;
-        user = user.populate({
+        var count;
+        var params = {
           path: 'createdLevels',
           select: 'title dateCreated starCount',
           options: options
-        })
+        };
+        if(levelType === 'created') {
+          params.match = { published: true };
+          count = user.totalCreatedLevels;
+        }
+        else if(levelType === 'drafts') {
+          params.match = { published: false };
+          count = user.totalDrafts;
+        }
+        user = user.populate(params)
         .execPopulate();
 
         return Promise.all([user, count])
@@ -315,7 +324,7 @@ export const getDocAndRunFunctionIfOwnerOrAdmin = (ModelStr, func) => (req, res,
 };
 
 export const getUserLevelsByTypeAndSend = () => (req, res, next) => {
-  const id = req.user !== undefined ? req.user._id : "56b0cccbd629fe4c81b15d54";
+  const id = req.user._id;
   const page = req.query.page !== undefined ? req.query.page-1 : 0;
   var userPromise = User.findById(id);
 
@@ -332,16 +341,17 @@ export const getUserProfileAndSend = () => (req, res, next) => {
   var created = getLevelsByType(userPromise, 'created', 0);
   var following = getLevelsByType(userPromise, 'following', 0);
   var liked = getLevelsByType(userPromise, 'liked', 0);
+  var drafts = getLevelsByType(userPromise, 'drafts', 0);
 
-  Promise.all([userPromise, created, following, liked])
-    .spread((user, created, following, liked) => {
+  Promise.all([userPromise, created, following, liked, drafts])
+    .spread((user, created, following, liked, drafts) => {
       user = user.populate({ path: 'followers', select: 'name', options: { limit: 5 }})
         .populate({ path: 'following', select: 'name', options: { limit: 5 }})
         .execPopulate();
         
-      return Promise.all([user, created, following, liked]);
+      return Promise.all([user, created, following, liked, drafts]);
     })
-    .spread((user, created, following, liked) => {
+    .spread((user, created, following, liked, drafts) => {
       res.json({
         user: {
           name: user.name,
@@ -356,7 +366,8 @@ export const getUserProfileAndSend = () => (req, res, next) => {
         },
         createdLevels: created,
         followingLevels: following,
-        likedLevels: liked
+        likedLevels: liked,
+        draftLevels: drafts
       })
     })
     .then(null, next);


### PR DESCRIPTION
- Added setLevelCounts method to user schema
  - creates separate counts for totalCreatedLevels and totalDrafts based on "published" flag in level schema
  - gets run when user adds created level (complete or draft)
- retrieving levels for profile separates drafts and complete created levels
- profile displays drafts and created levels separately
